### PR TITLE
Prevent re-run if already jailbroken

### DIFF
--- a/savedata/autoload.lua
+++ b/savedata/autoload.lua
@@ -133,7 +133,9 @@ end
 
 
 function main()
-    if not is_jailbroken() then
+    if is_jailbroken() then
+        file_touch(IS_JAILBROKEN_PATH)
+    else
         send_ps_notification("Jailbreak failed.\nClosing game...")
         syscall.kill(syscall.getpid(), 15)
         return

--- a/savedata/misc.lua
+++ b/savedata/misc.lua
@@ -40,6 +40,11 @@ function file_exists(name)
     end
  end
 
+function file_touch(filename)
+    local fd = io.open(filename, "w")
+    fd:close()
+end
+
 function file_write(filename, data, mode)
     local fd = io.open(filename, mode or "wb")
     fd:write(data)


### PR DESCRIPTION
It may happen that we accidentally start the game again, so don't run Lapse a second time.